### PR TITLE
升級 F2-3 form-with-bootstrap 成 Bootstrap5

### DIFF
--- a/F2-3_BackEnd/form-with-bootstrap/index.html
+++ b/F2-3_BackEnd/form-with-bootstrap/index.html
@@ -3,8 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <title>CodePen - Form with Bootstrap</title>
-  <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/css/bootstrap.min.css'><link rel="stylesheet" href="./style.css">
-
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+    rel="stylesheet"
+    integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+    crossorigin="anonymous"
+  />
 </head>
 <body>
 <!-- partial:index.partial.html -->
@@ -12,21 +16,21 @@
   <div class="row">
     <div class="col-sm-6">
       <form id="form" novalidate>
-        <div class="form-group">
-          <label for="name">姓名</label>
+        <div class="mb-3">
+          <label for="name" class="form-label">姓名</label>
           <input type="text" class="form-control" id="name" placeholder="請輸入你的全名 ..." required>
           <div class="valid-feedback"></div>
           <div class="invalid-feedback"></div>
         </div>
 
-        <div class="form-group">
-          <label for="email">電子郵件地址</label>
+        <div class="mb-3">
+          <label for="email" class="form-label">電子郵件地址</label>
           <input type="email" class="form-control" id="email" placeholder="請輸入你的電子郵件 ..." required>
           <div class="valid-feedback"></div>
           <div class="invalid-feedback"></div>
         </div>
 
-        <fieldset class="form-group" id="job-hunting-status">
+        <fieldset class="mb-3" id="job-hunting-status">
           <legend class="col-form-label" for="job-hunting-status">求職狀態</legend>
           <div class="form-check form-check-inline">
             <input class="form-check-input" name="job-hunting" type="radio" id="active" value="active">
@@ -50,21 +54,21 @@
           </div>
         </fieldset>
 
-        <div class="form-group">
-          <label>期望年資（萬元）</label>
-          <div class="form-row">
+        <div class="mb-3">
+          <label class="form-label">期望年資（萬元）</label>
+          <div class="row g-2 align-items-center">
             <div class="col">
               <input type="number" class="form-control" min="0">
             </div>
-            <p>-</p>
+            <div class="col flex-grow-0">-</div>
             <div class="col">
               <input type="number" class="form-control" min="0">
             </div>
           </div>
         </div>
 
-        <div class="form-group">
-          <label for="title">目前職稱</label>
+        <div class="mb-3">
+          <label for="title" class="form-label">目前職稱</label>
           <input list="titles" class="form-control">
           <datalist id="titles">
             <option>前端工程師</option>
@@ -76,7 +80,7 @@
           </datalist>
         </div>
 
-        <fieldset class="form-group" id="expected-job-type">
+        <fieldset class="mb-3" id="expected-job-type">
           <legend class="col-form-label" for="expected-job-type">期望工作型態</legend>
           <div class="form-check form-check-inline">
             <input class="form-check-input" name="job-type" type="checkbox" id="remote" value="remote">
@@ -112,7 +116,6 @@
   </div>
 </div>
 <!-- partial -->
-  <script  src="./script.js"></script>
-
+<script src="./script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
# 改動內容
- `.form-group` 已被棄用，用 `.mb-3` 代替
-  Bootstrap5 強制所有 <label> 要加上 `.form-label` 才有 style
- `.form-row` 已被棄用，改成普通的 `.row` 
   並且加上 `align-items-center g-2` 以維持原本的外觀
-  `.form-row p` 因應 `.for-row` 棄用有以下修改：
   - 將 p 改成 div ，避免預設的 margin-bottom
   - `.flex-grow-0` ，使它寬度不展開